### PR TITLE
fix #16

### DIFF
--- a/library.js
+++ b/library.js
@@ -2,7 +2,6 @@
 
 var plugin = {},
 	db = module.parent.require('./database'),
-	emitter = module.parent.require('./emitter'),
 	nconf = module.parent.require('nconf'),
 	fs = require('fs'),
 	path = require('path');

--- a/library.js
+++ b/library.js
@@ -116,9 +116,8 @@ plugin.init = function(params, callback) {
 					app.get('/' + route, middleware.buildHeader, renderCustomPage);
 					app.get('/api/' + route, renderCustomPage);
 
-					emitter.on('templates:compiled', function() {
-						fs.writeFile(path.join(nconf.get('views_dir'), route + '.tpl'), customTPL);
-					});
+					// Add template to compiled templates directory
+					fs.writeFile(path.join(nconf.get('views_dir'), route + '.tpl'), customTPL);
 				}
 			}
 		});


### PR DESCRIPTION
Templates compiled now before `static:app.init` is called, so no need for emitter.