### PR TITLE
Add empty db field case

### DIFF
--- a/library.js
+++ b/library.js
@@ -27,6 +27,10 @@ function getCustomPages(callback) {
 		try {
 			var pages = JSON.parse(data);
 
+			if (pages == null) {
+				pages = [];
+			}
+
 			// Eliminate errors in route definition
 			pages = pages.map(function(pageObj) {
 				pageObj.route = pageObj.route.replace(/^\/*/g, '');	// trim leading slashes from route


### PR DESCRIPTION
Since `db.set` gets only called within the socket route, this plugin interrupts the filter hooks with an error `Cannot call method 'map' of null` on a fresh setup.

Fixes #29 